### PR TITLE
coding the analog in task in a more flexible way

### DIFF
--- a/AtticusServer/Atticus.csproj
+++ b/AtticusServer/Atticus.csproj
@@ -78,8 +78,9 @@
     <Reference Include="NationalInstruments.Common, Version=9.1.35.159, Culture=neutral, PublicKeyToken=18cbae0f9955702a, processorArchitecture=MSIL">
       <Private>True</Private>
     </Reference>
-    <Reference Include="NationalInstruments.DAQmx, Version=9.3.35.219, Culture=neutral, PublicKeyToken=18cbae0f9955702a, processorArchitecture=x86">
-      <Private>True</Private>
+    <Reference Include="NationalInstruments.DAQmx, Version=8.7.35.25, Culture=neutral, PublicKeyToken=18cbae0f9955702a, processorArchitecture=x86">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>bin\Debug\NationalInstruments.DAQmx.dll</HintPath>
     </Reference>
     <Reference Include="NationalInstruments.NI4882, Version=9.0.35.157, Culture=neutral, PublicKeyToken=18cbae0f9955702a, processorArchitecture=MSIL">
       <Private>True</Private>

--- a/AtticusServer/ServerRuntime/AnalogInChannels.cs
+++ b/AtticusServer/ServerRuntime/AnalogInChannels.cs
@@ -8,211 +8,286 @@ namespace AtticusServer
     [Serializable, TypeConverter(typeof(ExpandableObjectConverter))]
     public class AnalogInChannels
     {
-        #region Single
+        //<AD>
+        #region Old Code
+        //#region Single
+
+        //private bool aS0;
+        //[Description("AS0.")]
+        //public bool AS0
+        //{
+        //    get { return aS0; }
+        //    set { aS0 = value; }
+        //}
         
-        private bool aS0;
-        [Description("AS0.")]
-        public bool AS0
-        {
-            get { return aS0; }
-            set { aS0 = value; }
-        }
-        
-        private bool aS1;
-        [Description("AS1.")]
-        public bool AS1
-        {
-            get { return aS1; }
-            set { aS1 = value; }
-        }
+        //private bool aS1;
+        //[Description("AS1.")]
+        //public bool AS1
+        //{
+        //    get { return aS1; }
+        //    set { aS1 = value; }
+        //}
 
-        private bool aS2;
-        [Description("AS2.")]
-        public bool AS2
-        {
-            get { return aS2; }
-            set { aS2 = value; }
-        }
+        //private bool aS2;
+        //[Description("AS2.")]
+        //public bool AS2
+        //{
+        //    get { return aS2; }
+        //    set { aS2 = value; }
+        //}
 
-        private bool aS3;
-        [Description("AS3.")]
-        public bool AS3
-        {
-            get { return aS3; }
-            set { aS3 = value; }
-        }
+        //private bool aS3;
+        //[Description("AS3.")]
+        //public bool AS3
+        //{
+        //    get { return aS3; }
+        //    set { aS3 = value; }
+        //}
 
-        private bool aS4;
-        [Description("AS4.")]
-        public bool AS4
-        {
-            get { return aS4; }
-            set { aS4 = value; }
-        }
+        //private bool aS4;
+        //[Description("AS4.")]
+        //public bool AS4
+        //{
+        //    get { return aS4; }
+        //    set { aS4 = value; }
+        //}
 
-        private bool aS5;
-        [Description("AS5.")]
-        public bool AS5
-        {
-            get { return aS5; }
-            set { aS5 = value; }
-        }
+        //private bool aS5;
+        //[Description("AS5.")]
+        //public bool AS5
+        //{
+        //    get { return aS5; }
+        //    set { aS5 = value; }
+        //}
 
-        private bool aS6;
-        [Description("AS6.")]
-        public bool AS6
-        {
-            get { return aS6; }
-            set { aS6 = value; }
-        }
+        //private bool aS6;
+        //[Description("AS6.")]
+        //public bool AS6
+        //{
+        //    get { return aS6; }
+        //    set { aS6 = value; }
+        //}
 
-        private bool aS7;
-        [Description("AS7.")]
-        public bool AS7
-        {
-            get { return aS7; }
-            set { aS7 = value; }
-        }
+        //private bool aS7;
+        //[Description("AS7.")]
+        //public bool AS7
+        //{
+        //    get { return aS7; }
+        //    set { aS7 = value; }
+        //}
 
-        private bool aS8;
-        [Description("AS8.")]
-        public bool AS8
-        {
-            get { return aS8; }
-            set { aS8 = value; }
-        }
+        //private bool aS8;
+        //[Description("AS8.")]
+        //public bool AS8
+        //{
+        //    get { return aS8; }
+        //    set { aS8 = value; }
+        //}
 
-        private bool aS9;
-        [Description("AS9.")]
-        public bool AS9
-        {
-            get { return aS9; }
-            set { aS9 = value; }
-        }
+        //private bool aS9;
+        //[Description("AS9.")]
+        //public bool AS9
+        //{
+        //    get { return aS9; }
+        //    set { aS9 = value; }
+        //}
 
-        #endregion Single
+        //#endregion Single
        
-        #region Differential
+        //#region Differential
         
-        private bool aD0;
-        [Description("AD0.")]
-        public bool AD00
+        //private bool aD0;
+        //[Description("AD0.")]
+        //public bool AD00
+        //{
+        //    get { return aD0; }
+        //    set { aD0 = value; }
+        //}
+
+        //private bool aD1;
+        //[Description("AD1.")]
+        //public bool AD01
+        //{
+        //    get { return aD1; }
+        //    set { aD1 = value; }
+        //}
+
+        //private bool aD2;
+        //[Description("AD2.")]
+        //public bool AD02
+        //{
+        //    get { return aD2; }
+        //    set { aD2 = value; }
+        //}
+
+        //private bool aD3;
+        //[Description("AD3.")]
+        //public bool AD03
+        //{
+        //    get { return aD3; }
+        //    set { aD3 = value; }
+        //}
+
+        //private bool aD4;
+        //[Description("AD4.")]
+        //public bool AD04
+        //{
+        //    get { return aD4; }
+        //    set { aD4 = value; }
+        //}
+
+        //private bool aD5;
+        //[Description("AD5.")]
+        //public bool AD05
+        //{
+        //    get { return aD5; }
+        //    set { aD5 = value; }
+        //}
+
+        //private bool aD6;
+        //[Description("AD6.")]
+        //public bool AD06
+        //{
+        //    get { return aD6; }
+        //    set { aD6 = value; }
+        //}
+
+        //private bool aD7;
+        //[Description("AD7.")]
+        //public bool AD07
+        //{
+        //    get { return aD7; }
+        //    set { aD7 = value; }
+        //}
+
+        //private bool aD8;
+        //[Description("AD8.")]
+        //public bool AD08
+        //{
+        //    get { return aD8; }
+        //    set { aD8 = value; }
+        //}
+
+        //private bool aD9;
+        //[Description("AD9.")]
+        //public bool AD09
+        //{
+        //    get { return aD9; }
+        //    set { aD9 = value; }
+        //}
+
+        //private bool aD10;
+        //[Description("AD10.")]
+        //public bool AD10
+        //{
+        //    get { return aD10; }
+        //    set { aD10 = value; }
+        //}
+
+        //#endregion Differential
+
+        #endregion
+
+
+        private string deviceName = AtticusServer.server.serverSettings.AIDev;
+
+        [Description(""),
+        Category("Names")]
+        public string DeviceName
         {
-            get { return aD0; }
-            set { aD0 = value; }
+            get { return deviceName; }
+            //set { serverName = value; }
         }
 
-        private bool aD1;
-        [Description("AD1.")]
-        public bool AD01
+        private string channelName;
+
+        [Description(""),
+        Category("Names")]
+        public string ChannelName
         {
-            get { return aD1; }
-            set { aD1 = value; }
+            get { return channelName; }
+            set { channelName = value; }
         }
 
-        private bool aD2;
-        [Description("AD2.")]
-        public bool AD02
+        private string saveName;
+
+        [Description(""),
+        Category("Names")]
+        public string SaveName
         {
-            get { return aD2; }
-            set { aD2 = value; }
+            get { return saveName; }
+            set { saveName = value; }
         }
 
-        private bool aD3;
-        [Description("AD3.")]
-        public bool AD03
+        private string label;
+
+        [Description(""),
+        Category("Names")]
+        public string Label
         {
-            get { return aD3; }
-            set { aD3 = value; }
+            get { return label; }
+            set { label = value; }
         }
 
-        private bool aD4;
-        [Description("AD4.")]
-        public bool AD04
+        public enum AnalogInChannelTypeList { SingleEnded, Differential };
+
+        private AnalogInChannelTypeList analogInChannelType;
+
+        [Description(""),
+        Category("Settings")]
+        public AnalogInChannelTypeList AnalogInChannelType
         {
-            get { return aD4; }
-            set { aD4 = value; }
+            get { return analogInChannelType; }
+            set { analogInChannelType = value; }
         }
 
-        private bool aD5;
-        [Description("AD5.")]
-        public bool AD05
-        {
-            get { return aD5; }
-            set { aD5 = value; }
-        }
+        private bool useChannel = false;
 
-        private bool aD6;
-        [Description("AD6.")]
-        public bool AD06
+        [Description(""),
+        Category("Settings")]
+        public bool UseChannel
         {
-            get { return aD6; }
-            set { aD6 = value; }
+            get { return useChannel; }
+            set { useChannel = value; }
         }
-
-        private bool aD7;
-        [Description("AD7.")]
-        public bool AD07
-        {
-            get { return aD7; }
-            set { aD7 = value; }
-        }
-
-        private bool aD8;
-        [Description("AD8.")]
-        public bool AD08
-        {
-            get { return aD8; }
-            set { aD8 = value; }
-        }
-
-        private bool aD9;
-        [Description("AD9.")]
-        public bool AD09
-        {
-            get { return aD9; }
-            set { aD9 = value; }
-        }
-
-        private bool aD10;
-        [Description("AD10.")]
-        public bool AD10
-        {
-            get { return aD10; }
-            set { aD10 = value; }
-        }
-
-        #endregion Differential
 
         public AnalogInChannels()
         {
+            #region OldCode
             #region Single
-            aS0 = false;
-            aS1 = false;
-            aS2 = false;
-            aS3 = false;
-            aS4 = false;
-            aS5 = false;
-            aS6 = false;
-            aS7 = false;
-            aS8 = false;
-            aS9 = false;
+            //aS0 = false;
+            //aS1 = false;
+            //aS2 = false;
+            //aS3 = false;
+            //aS4 = false;
+            //aS5 = false;
+            //aS6 = false;
+            //aS7 = false;
+            //aS8 = false;
+            //aS9 = false;
             #endregion Single
 
             #region Differential
-            aD0 = true;
-            aD1 = false;
-            aD2 = false;
-            aD3 = false;
-            aD4 = false;
-            aD5 = false;
-            aD6 = false;
-            aD7 = false;
-            aD8 = false;
-            aD9 = false;
-            aD10 = false;
+            //aD0 = true;
+            //aD1 = false;
+            //aD2 = false;
+            //aD3 = false;
+            //aD4 = false;
+            //aD5 = false;
+            //aD6 = false;
+            //aD7 = false;
+            //aD8 = false;
+            //aD9 = false;
+            //aD10 = false;
             #endregion Differential
+            #endregion OldCode
+
+            deviceName = AtticusServer.server.serverSettings.AIDev;
+            channelName = "ai";
+            saveName = "AI";
 
         }
+
+        //</AD>
     }
 }

--- a/AtticusServer/ServerRuntime/ServerSettings.cs
+++ b/AtticusServer/ServerRuntime/ServerSettings.cs
@@ -189,6 +189,44 @@ namespace AtticusServer
             set { connections = value; }
         }
 
+        //<AD>
+
+        private string aIDev;
+
+        [Description("Device to use for the analog in task. Ex: if the analog in ports are situated on 'Dev6/ai', set this field to 'Dev6'"),
+        Category("Analog In")]
+        public string AIDev
+        {
+            get { return aIDev; }
+            set { aIDev = value; }
+        }
+
+        /// <summary>
+        /// When set to true, the Analog In task will be triggered by a physical signal. The source of this signal is set with the 'AITriggerSource' field. This is useful if you want to synchronize the input task when using Variable Timebase, since the generation of the VariableTimebase source can take some time and jeopardize tasks synchronization.
+        /// </summary>
+        private bool useAITaskTriggering = false;
+
+        [Description("When set to true, the Analog In task will be triggered by a physical signal. The source of this signal is set with the 'AITriggerSource' field. This is useful if you want to synchronize the input task when using Variable Timebase, since the generation of the VariableTimebase source can take some time and jeopardize tasks synchronization."),
+        Category("Analog In")]
+        public bool UseAITaskTriggering
+        {
+            get { return useAITaskTriggering; }
+            set { useAITaskTriggering = value; }
+        }
+
+
+        private string aITriggerSource;
+
+        [Description("Source for triggering the analog in task (if UseAITaskTriggering set to true). Ex: 'PXI_Trig0'. NB : you can use the variable timebase source as a trigger. The task will be triggered by he rising edge at the beginning of the sequence, and will ignore the other edges until the sequence is over."),
+        Category("Analog In")]
+        public string AITriggerSource
+        {
+            get { return aITriggerSource; }
+            set { aITriggerSource = value; }
+        }
+
+        //</AD>
+
         private int aIFrequency=1000;
 
         [Description("Sampling frequency for the Analog In channels"),
@@ -209,15 +247,17 @@ namespace AtticusServer
             set { aIChannels = value; }
         }
 
-        private List<AnalogInNames> aINames;
+        //<AD>
+        //private List<AnalogInNames> aINames;   // adareau : this is now obsolete
 
-        [Description("Custom names for the Analog In channels"),
-        Category("Analog In")]
-        public List<AnalogInNames> AINames
-        {
-            get { return aINames; }
-            set { aINames = value; }
-        }
+        //[Description("Custom names for the Analog In channels"),
+        //Category("Analog In")]
+        //public List<AnalogInNames> AINames
+        //{
+        //    get { return aINames; }
+        //    set { aINames = value; }
+        //}
+        //</AD>
 
         private List<AnalogInLogTime> aILogTimes;
 
@@ -355,7 +395,7 @@ namespace AtticusServer
             this.connections = new List<TerminalPair>();
             this.aILogTimes = new List<AnalogInLogTime>();
             this.aIChannels = new List<AnalogInChannels>();
-            this.aINames = new List<AnalogInNames>();
+            //this.aINames = new List<AnalogInNames>(); // now obsolete
             this.versionNumberAtFirstCreation = DataStructuresVersionNumber.CurrentVersion;
             this.versionNumberAtLastSerialization = DataStructuresVersionNumber.CurrentVersion;
         }

--- a/AtticusServer/app.config
+++ b/AtticusServer/app.config
@@ -8,6 +8,10 @@
 				<bindingRedirect oldVersion="0.0.0.0-8.5.20.149" newVersion="8.5.20.149"/>
 			</dependentAssembly>
       -->
+			<dependentAssembly>
+				<assemblyIdentity name="NationalInstruments.Common" publicKeyToken="18CBAE0F9955702A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-9.1.35.159" newVersion="9.1.35.159"/>
+			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>
 <startup><supportedRuntime version="v2.0.50727"/></startup></configuration>


### PR DESCRIPTION
Now analog in channels can be declared and configured using the
ServerSettings object editor.

The analog in task can also be triggered by an external source, allowing
for good synchronization even when a variable timebase is used.

PS : for some reason, to have atticus compiled on my computer, I had to
move the "Opal Kelly" directory into the "AtticusServer" one. I do not
commit this change, but this is weird.

PPS: this is my first time using github, so if I did something wrong please let me know :)
